### PR TITLE
後方互換性がないためバージョン番号をv5.1.1からv6.0.0へ変更

### DIFF
--- a/src/nucosen/__init__.py
+++ b/src/nucosen/__init__.py
@@ -15,4 +15,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-__version__ = "5.1.1b3"
+__version__ = "6.0.0"


### PR DESCRIPTION
**目的と概要**

「 #112 」を受けて、後方互換性がなくなったためバージョン番号の更新

**変更点・修正箇所**

バージョン番号のみ。

**影響範囲**

表示上のみ
（ [v5.1.1](https://github.com/nucosen/broadcast/releases/tag/v5.1.1)からの大きな変更なし ）

**実施したテストと結果**

v5.1.1として動作試験およびベータリリース実施済み。
v6.0.0としてインストールの成功を確認済み。
